### PR TITLE
First pass at python3 compatibility for profile state and module

### DIFF
--- a/_states/profile.py
+++ b/_states/profile.py
@@ -22,11 +22,14 @@ create and install configuration profiles.
                 ...
 
 '''
+
+
 import logging
+import pprint
+
+import salt.exceptions
 import salt.utils
 import salt.utils.platform
-import salt.exceptions
-import pprint
 
 
 log = logging.getLogger(__name__)
@@ -90,7 +93,7 @@ def installed(name, force=None, **kwargs):
         return ret
 
     mcpath = __salt__['temp.file']('.mobileconfig', 'salt')
-    f = open(mcpath, "w")
+    f = open(mcpath, "wb")
     f.write(content)
     f.close()
 


### PR DESCRIPTION
I used this to create and manage a Software Update config with the current python3 Salt release... Until @weswhet talked me out of it.

I don't have any legacy python salt sitting around to test this on, so give it a test first in your environments. Just in messing around in the interpreter, legacy python definitely takes everything that is marked here as bytes and turns them into strings. It also has no qualms about formatting a unicode UUID into a string. Python 3 is much more strict about that (and it works).

My work on this wasn't exhaustive, but this got me to a working state for managing a handful of profiles.