### PR TITLE
Ard py3

### DIFF
--- a/_modules/ard.py
+++ b/_modules/ard.py
@@ -9,11 +9,12 @@ manage the "remote management" service via kickstart and property lists.
 '''
 # This would not have been possible without the hard work from dayglojesus/managedmac
 
-import os
-import logging
 import binascii
-import salt.utils
+import logging
+import os
+
 from salt.exceptions import CommandExecutionError
+import salt.utils
 
 log = logging.getLogger(__name__)
 

--- a/_modules/ard.py
+++ b/_modules/ard.py
@@ -13,8 +13,8 @@ import binascii
 import logging
 import os
 
-from salt.exceptions import CommandExecutionError
 import salt.utils
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 

--- a/_modules/ard.py
+++ b/_modules/ard.py
@@ -85,7 +85,7 @@ _NAPRIVS = {
     'restart_shutdown': _NAPRIV_RESTART_SHUTDOWN
 }
 
-_NAPRIVS_FLIP = {y: x for x, y in _NAPRIVS.iteritems()}
+_NAPRIVS_FLIP = {y: x for x, y in _NAPRIVS.items()}
 
 
 def __virtual__():
@@ -137,7 +137,7 @@ def _naprivs_to_list(naprivs):
     if naprivs & _NAPRIV_ALL == _NAPRIV_ALL:
         privs = ['all']
     else:
-        privs = [k for k, v in _NAPRIVS.iteritems() if naprivs & v == v]
+        privs = [k for k, v in _NAPRIVS.items() if naprivs & v == v]
 
     if _is_notified(naprivs):
         privs.append('observe_notified')
@@ -352,7 +352,7 @@ def users(human=True):
     if not human:
         return privs
 
-    privs_human = {user: _naprivs_to_list(int(privs)) for user, privs in privs.iteritems()}
+    privs_human = {user: _naprivs_to_list(int(privs)) for user, privs in privs.items()}
     return privs_human
 
 

--- a/_modules/ard.py
+++ b/_modules/ard.py
@@ -4,7 +4,7 @@ manage the "remote management" service via kickstart and property lists.
 
 :maintainer:    Mosen <mosen@github.com>
 :maturity:      beta
-:depends:       plist
+:depends:       mac_prefs
 :platform:      darwin
 '''
 # This would not have been possible without the hard work from dayglojesus/managedmac

--- a/_modules/ard.py
+++ b/_modules/ard.py
@@ -225,14 +225,10 @@ def active():
     #     log.debug('Not listening on tcp 3283 (remote desktop)')
     #     return False
 
-    # Is the trigger file present?
-    if not os.path.isfile(_PATHS['trigger']):
-        log.debug('Remote Management trigger file: {0} does not exist.'.format(_PATHS['trigger']))
-        return False
-
     # Is the ARDAgent process running?
     # TODO: OSX implementation ps.pgrep
-    if not __salt__['cmd.retcode']('ps axc | grep ARDAgent > /dev/null', python_shell=False) == 0:
+    if not __salt__['cmd.retcode'](
+            'ps axc | grep ARDAgent &> /dev/null', python_shell=True, ignore_retcode=True) == 0:
         log.debug('ARDAgent process is not running.')
         return False
 

--- a/_states/ard.py
+++ b/_states/ard.py
@@ -129,8 +129,8 @@ def managed(name, enabled=None, **kwargs):
         changes['new']['directory_groups'] = kwargs['directory_groups']
 
     desired_prefs = {_ATTR_TO_KEY[k]: v for k, v in kwargs.items() if k in _ATTR_TO_KEY}
-    prefs_to_set = {k: v for k, v in desired_prefs.items() if v != current_prefs[k]}
-    incorrect_prefs = {k: current_prefs[k] for k in prefs_to_set}
+    prefs_to_set = {k: v for k, v in desired_prefs.items() if v != current_prefs.get(k)}
+    incorrect_prefs = {k: current_prefs.get(k, 'NOT SET') for k in prefs_to_set}
     if prefs_to_set:
         changes['old'].update(incorrect_prefs)
         changes['new'].update(prefs_to_set)

--- a/_states/ard.py
+++ b/_states/ard.py
@@ -44,9 +44,7 @@ def __virtual__():
     return __virtualname__ if salt.utils.platform.is_darwin() else False
 
 
-_PATHS = {
-    'preferences': '/Library/Preferences/com.apple.RemoteManagement.plist'
-}
+_PREF_DOMAIN = 'com.apple.RemoteManagement'
 
 # These keys dont require any munging, just comparison against desired state.
 _ATTR_TO_KEY = {
@@ -58,7 +56,7 @@ _ATTR_TO_KEY = {
     'allow_wbem_requests': 'WBEMIncomingAccessEnabled'
 }
 
-_KEY_TO_ATTR = {y: x for x, y in _ATTR_TO_KEY.iteritems()}
+_KEY_TO_ATTR = {y: x for x, y in _ATTR_TO_KEY.items()}
 
 
 def managed(name, enabled=True, **kwargs):
@@ -102,18 +100,18 @@ def managed(name, enabled=True, **kwargs):
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
     changes = {'old': {}, 'new': {}}
 
-    # Not all property list values can simply be compared, some values need munging before the comparison. eg.privileges
-    current_plist = __salt__['plist.read'](_PATHS['preferences'])
     service_is_enabled = __salt__['ard.active']()
-    if 'ARD_AllLocalUsersPrivs' in current_plist:
-        all_users_privs = __salt__['ard.naprivs_list'](current_plist['ARD_AllLocalUsersPrivs'])
+    # Not all values can simply be compared, some values need munging before the comparison. eg.privileges
+    current_prefs = __salt__['prefs.list'](_PREF_DOMAIN, user='any', host='any', values=True)
+    if 'ARD_AllLocalUsersPrivs' in current_prefs:
+        all_users_privs = __salt__['ard.naprivs_list'](current_prefs['ARD_AllLocalUsersPrivs'])
     else:
-        all_users_privs = list()
+        all_users_privs = []
 
     vnc_password = __salt__['ard.vncpw']()
-    directory_groups = current_plist['DirectoryGroupList'] if 'DirectoryGroupList' in current_plist else list()
+    directory_groups = current_prefs.get('DirectoryGroupList', [])
 
-    if enabled != service_is_enabled:
+    if enabled is not None and enabled != service_is_enabled:
         changes['old']['enabled'] = service_is_enabled
         changes['new']['enabled'] = enabled
 
@@ -129,35 +127,42 @@ def managed(name, enabled=True, **kwargs):
         changes['old']['directory_groups'] = list(directory_groups)
         changes['new']['directory_groups'] = kwargs['directory_groups']
 
-    desired_prefs = {_ATTR_TO_KEY[k]: v for k, v in kwargs.iteritems() if k in _ATTR_TO_KEY}
-    changed_prefs = dict(current_plist)
-    for k, v in desired_prefs.iteritems():
-        changed_prefs[k] = v
+    desired_prefs = {_ATTR_TO_KEY[k]: v for k, v in kwargs.items() if k in _ATTR_TO_KEY}
+    prefs_to_set = {k: v for k, v in desired_prefs.items() if v != current_prefs[k]}
+    incorrect_prefs = {k: current_prefs[k] for k in prefs_to_set}
+    if prefs_to_set:
+        changes['old'].update(incorrect_prefs)
+        changes['new'].update(prefs_to_set)
 
     if __opts__['test'] == True:
         ret['changes'] = changes
         ret['result'] = None
+
     else:
         ret['result'] = True
 
-        if len(changes['new'].keys()) == 0:
-            ret['result'] = True
+        if len(changes['new']) == 0:
             ret['comment'] = 'No changes required'
         else:
-            if changes['new'].get('vnc_password', False):
+            if 'vnc_password' in changes['new']:
                 __salt__['ard.set_vncpw'](changes['new']['vnc_password'])
 
-            if changed_prefs:
-                if 'all_users_privs' in changes['new']:
-                    all_users_naprivs = __salt__['ard.list_naprivs'](','.join(changes['new']['all_users_privs']))
-                    log.debug('Setting remote management all users privilege to: {0}'.format(all_users_naprivs))
-                    changed_prefs['ARD_AllLocalUsersPrivs'] = str(all_users_naprivs)
+            if 'all_users_privs' in changes['new']:
+                all_users_naprivs = __salt__['ard.list_naprivs'](
+                    ','.join(changes['new']['all_users_privs']))
+                log.debug('Setting remote management all users privilege to: {0}'.format(
+                    all_users_naprivs))
+                prefs_to_set['ARD_AllLocalUsersPrivs'] = str(all_users_naprivs)
 
-                if 'directory_groups' in changes['new']:
-                    changed_prefs['DirectoryGroupList'] = changes['new']['directory_groups']
+            if 'directory_groups' in changes['new']:
+                prefs_to_set['DirectoryGroupList'] = changes['new']['directory_groups']
 
-                log.debug('Attempting to write new Remote Management preferences: {0}'.format(changed_prefs))
-                __salt__['plist.write_keys'](_PATHS['preferences'], changed_prefs)
+            if prefs_to_set:
+                log.debug('Attempting to write new Remote Management preferences: {0}'.format(
+                    prefs_to_set))
+                for k, v in prefs_to_set.items():
+                    __salt__['prefs.set'](
+                        name=k, value=v, domain=_PREF_DOMAIN, user='any', host='any')
 
             if 'enabled' in changes['new']:
                 if changes['new']['enabled']:

--- a/_states/ard.py
+++ b/_states/ard.py
@@ -59,7 +59,7 @@ _ATTR_TO_KEY = {
 _KEY_TO_ATTR = {y: x for x, y in _ATTR_TO_KEY.items()}
 
 
-def managed(name, enabled=True, **kwargs):
+def managed(name, enabled=None, **kwargs):
     '''
     Enforce "remote management" (ARD) service settings.
     per-user privileges are set via the ard.privileges state.
@@ -67,8 +67,9 @@ def managed(name, enabled=True, **kwargs):
     name
         This is mostly irrelevant since the settings are system wide.
 
-    enabled : True
-        Whether the remote management service is active and should start on boot.
+    enabled : None
+        Whether the remote management service is active and should start on boot. If this param is
+        omitted, the service will not be enabled or disabled.
 
     allow_all_users
         Should all local users be allowed to connect?


### PR DESCRIPTION
This PR is to update the ARD module to work for python3. As part of this, some issues were corrected and features were added. A summary:
- Updates ard execution and state modules to work in python3.
- Provides clear TODO comments about code that is removable once legacy python is no longer needed.
- Fixes `ard.active` execution func to work correctly.
- Fixes `ard.managed` state func to use CFPrefs via the mac_prefs module instead of the plist module, both for checking and setting preference state.
- Corrects `ard.managed` state func to include preferences in the ret dict's `changes` dict.
- Adds the ability to do `ard.managed` with an `enabled=None` value, which is the new default, to not change the activation of the ARDAgent, but still manage other settings.