### PR TITLE
Add execution and state modules for Xcode Command Line Tools.

### DIFF
--- a/_modules/xcode_command_line_tools.py
+++ b/_modules/xcode_command_line_tools.py
@@ -78,7 +78,11 @@ def install():
 
     # Remove the trigger file so softwareupdate doesn't continue to
     # offer the command line tools.
-    os.unlink(trigger)
+    try:
+        os.unlink(trigger)
+    except OSError:
+        # The file got removed already.
+        pass
 
     return result
 

--- a/_modules/xcode_command_line_tools.py
+++ b/_modules/xcode_command_line_tools.py
@@ -53,8 +53,10 @@ def install():
     available_updates = __salt__['softwareupdate.list_available']()
     # Example label 10.14:
     # Command Line Tools (macOS Mojave version 10.14) for Xcode-10.3
-    # Example label 10.15:
+    # Example label Beta:
     # Command Line Tools beta 6 for Xcode-11.0
+    # Example Catalina result:
+    # Command Line Tools for Xcode-11.0
 
     pattern = re.compile(r'Command Line Tools [\(\)\w\s.]+ for Xcode-[\d.]+')
 

--- a/_modules/xcode_command_line_tools.py
+++ b/_modules/xcode_command_line_tools.py
@@ -80,7 +80,7 @@ def install():
     # offer the command line tools.
     try:
         os.unlink(trigger)
-    except OSError:
+    except (OSError, FileNotFoundError):
         # The file got removed already.
         pass
 

--- a/_modules/xcode_command_line_tools.py
+++ b/_modules/xcode_command_line_tools.py
@@ -22,14 +22,14 @@ from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
-__virtualname__ = 'xcode_command_line_tools'
+__virtualname__ = "xcode_command_line_tools"
 
 
 def __virtual__():
     """Only load if the platform is macOS"""
-    if __grains__.get('kernel') != 'Darwin':
+    if __grains__.get("kernel") != "Darwin":
         return False
-    if StrictVersion(__grains__['osrelease']) < StrictVersion('10.9'):
+    if StrictVersion(__grains__["osrelease"]) < StrictVersion("10.9"):
         return False
     return __virtualname__
 
@@ -46,11 +46,10 @@ def install():
     # Touch the trigger file to coerce softwareupdate into offering the
     # command line tools.
     trigger = "/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
-    with open(trigger, 'w') as trigger_handle:
-        trigger_handle.write('')
+    __salt__["file.touch"](trigger)
 
-    available_updates = __salt__['softwareupdate.list_available']()
-    logging.debug('Available updates: %s', available_updates)
+    available_updates = __salt__["softwareupdate.list_available"]()
+    logging.debug("Available updates: %s", available_updates)
     # Example label 10.14:
     # Command Line Tools (macOS Mojave version 10.14) for Xcode-10.3
     # Example label Beta:
@@ -58,31 +57,27 @@ def install():
     # Example Catalina result:
     # Command Line Tools for Xcode-11.0
 
-    pattern = re.compile(r'Command Line Tools[\(\)\w\s.]* for Xcode-[\d.]+')
+    pattern = re.compile(r"Command Line Tools[\(\)\w\s.]* for Xcode-[\d.]+")
 
     # Filter out versions that aren't for this OS release.
-    candidates = [(update, version) for update, version in available_updates.items()
-                  if pattern.match(update)]
-    logging.debug('Command Line Tools candidates: %s', candidates)
+    candidates = [
+        (update, version) for update, version in available_updates.items() if pattern.match(update)
+    ]
+    logging.debug("Command Line Tools candidates: %s", candidates)
 
     if candidates:
         # Sort by version number and get the newest (last) update name.
         newest_update = sorted(candidates, key=lambda i: StrictVersion(i[1]))[-1][0]
-        logging.debug('Selected Command Line Tools: %s', newest_update)
-        cmd = ['softwareupdate', '--install', newest_update]
-        __salt__['cmd.run'](cmd)
+        logging.debug("Selected Command Line Tools: %s", newest_update)
+        cmd = ["softwareupdate", "--install", newest_update]
+        __salt__["cmd.run"](cmd)
         result = check()
     else:
         result = False
 
     # Remove the trigger file so softwareupdate doesn't continue to
     # offer the command line tools.
-    try:
-        os.unlink(trigger)
-    except (OSError, FileNotFoundError):
-        # The file got removed already, possibly by the user.
-        # Nothing else to do.
-        pass
+    __salt__["file.remove"](trigger)
 
     return result
 
@@ -98,7 +93,7 @@ def check():
 
         salt '*' xcode_command_line_tools.check
     """
-    cmd = ['xcode-select', '-p']
+    cmd = ["xcode-select", "-p"]
     try:
         return salt.utils.mac_utils.execute_return_success(cmd)
     except CommandExecutionError:

--- a/_modules/xcode_command_line_tools.py
+++ b/_modules/xcode_command_line_tools.py
@@ -43,10 +43,9 @@ def install():
 
         salt '*' xcode_command_line_tools.install
     """
-    trigger = "/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
-
     # Touch the trigger file to coerce softwareupdate into offering the
     # command line tools.
+    trigger = "/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
     with open(trigger, 'w') as trigger_handle:
         trigger_handle.write('')
 
@@ -81,7 +80,8 @@ def install():
     try:
         os.unlink(trigger)
     except (OSError, FileNotFoundError):
-        # The file got removed already.
+        # The file got removed already, possibly by the user.
+        # Nothing else to do.
         pass
 
     return result

--- a/_modules/xcode_command_line_tools.py
+++ b/_modules/xcode_command_line_tools.py
@@ -1,0 +1,98 @@
+"""macOS Xcode command line tools module
+
+This is a macOS execution module which will install and report on the
+status of the Xcode command line tools package, which among other
+things contains git, gcc, etc.
+
+:maintainer:    Shea Craig <shea.craig@sas.com>
+:maturity:      new
+:depends:       None
+:platform:      darwin
+"""
+
+
+import logging
+import os
+import re
+from distutils.version import StrictVersion
+
+import salt.utils.mac_utils
+from salt.exceptions import CommandExecutionError
+
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'xcode_command_line_tools'
+
+
+def __virtual__():
+    """Only load if the platform is macOS"""
+    if __grains__.get('kernel') != 'Darwin':
+        return False
+    if StrictVersion(__grains__['osrelease']) < StrictVersion('10.9'):
+        return False
+    return __virtualname__
+
+
+def install():
+    """Install the Xcode command line tools.
+
+    :return: Bool indicating success or failure.
+
+    CLI Example::
+
+        salt '*' xcode_command_line_tools.install
+    """
+    trigger = "/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
+
+    # Touch the trigger file to coerce softwareupdate into offering the
+    # command line tools.
+    with open(trigger, 'w') as trigger_handle:
+        trigger_handle.write('')
+
+    available_updates = __salt__['softwareupdate.list_available']()
+    # Example label 10.14:
+    # Command Line Tools (macOS Mojave version 10.14) for Xcode-10.3
+    # Example label 10.15:
+    # Command Line Tools beta 6 for Xcode-11.0
+
+    pattern = re.compile(r'Command Line Tools [\(\)\w\s.]+ for Xcode-[\d.]+')
+
+    # Filter out versions that aren't for this OS release.
+    candidates = [(update, version) for update, version in available_updates.items()
+                  if pattern.match(update)]
+    logging.debug('Command Line Tools candidates: %s', candidates)
+
+    if candidates:
+        # Sort by version number and get the newest (last) update name.
+        newest_update = sorted(candidates, key=lambda i: StrictVersion(i[1]))[-1][0]
+        logging.debug('Selected Command Line Tools: %s', newest_update)
+        cmd = ['softwareupdate', '--install', newest_update]
+        __salt__['cmd.run'](cmd)
+        result = check()
+    else:
+        result = False
+
+    # Remove the trigger file so softwareupdate doesn't continue to
+    # offer the command line tools.
+    os.unlink(trigger)
+
+    return result
+
+
+def check():
+    """Check to see if the command line tools are installed.
+
+    This includes checking that they are installed for this OS version.
+
+    :return: Boolean.
+
+    CLI Example::
+
+        salt '*' xcode_command_line_tools.check
+    """
+    cmd = ['xcode-select', '-p']
+    try:
+        return salt.utils.mac_utils.execute_return_success(cmd)
+    except CommandExecutionError:
+        return False

--- a/_modules/xcode_command_line_tools.py
+++ b/_modules/xcode_command_line_tools.py
@@ -51,6 +51,7 @@ def install():
         trigger_handle.write('')
 
     available_updates = __salt__['softwareupdate.list_available']()
+    logging.debug('Available updates: %s', available_updates)
     # Example label 10.14:
     # Command Line Tools (macOS Mojave version 10.14) for Xcode-10.3
     # Example label Beta:
@@ -58,7 +59,7 @@ def install():
     # Example Catalina result:
     # Command Line Tools for Xcode-11.0
 
-    pattern = re.compile(r'Command Line Tools [\(\)\w\s.]+ for Xcode-[\d.]+')
+    pattern = re.compile(r'Command Line Tools[\(\)\w\s.]* for Xcode-[\d.]+')
 
     # Filter out versions that aren't for this OS release.
     candidates = [(update, version) for update, version in available_updates.items()

--- a/_states/xcode_command_line_tools.py
+++ b/_states/xcode_command_line_tools.py
@@ -1,0 +1,50 @@
+"""State for managing the Xcode command line tools"""
+
+
+import logging
+
+import salt.utils.platform
+
+
+log = logging.getLogger(__name__)
+
+
+__virtualname__ = 'xcode_command_line_tools'
+
+
+def __virtual__():
+    """Only make available for the Mac platform."""
+    if salt.utils.platform.is_darwin():
+        return __virtualname__
+    else:
+        return False, 'state.xcode_command_line_tools only available on macOS'
+
+
+def installed(name):
+    """Ensure that Xcode command line tools are installed."""
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    result = __salt__['xcode_command_line_tools.check']()
+
+    if result:
+        ret['result'] = True
+        ret['comment'] = 'Xcode command line tools already installed.'
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Xcode command line tools would be installed.'
+        return ret
+
+    __salt__['xcode_command_line_tools.install']()
+    ret['result'] = __salt__['xcode_command_line_tools.check']()
+
+    if not ret['result']:
+        ret['comment'] = 'Xcode command line tools were not installed.'
+    else:
+        ret['comment'] = 'Xcode command line tools were installed.'
+
+    return ret


### PR DESCRIPTION
This PR adds execution and state modules for ensuring the command line tools are installed.

They unfortunately require an updated mac_softwareupdate module to work on Catalina, although that's already been PR'ed to Salt.

Once that makes its way in, I'll try to add this functionality into the mac_softwareupdate module, or at least see if I can get this added to Salt proper.