### PR TITLE
Add three different grains for user accounts.

### DIFF
--- a/_grains/non_system_users.py
+++ b/_grains/non_system_users.py
@@ -1,0 +1,34 @@
+"""Grain to get user accounts on a macOS system."""
+
+
+import logging
+import re
+
+import salt.modules.cmdmod
+import salt.utils.platform
+
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'users'
+
+
+def __virtual__():
+    if salt.utils.platform.is_darwin():
+        return __virtualname__
+    else:
+        return False
+
+# Chicken and egg problem, SaltStack style
+# __salt__ is already populated with grains by this stage.
+cmdmod = {
+    'cmd.run': salt.modules.cmdmod._run_quiet,
+}
+
+
+def users():
+    return {'macos_users': [u for u in _get_users() if not u.startswith('_')]}
+
+
+def _get_users():
+    return cmdmod['cmd.run']('dscl . list /Users').splitlines()

--- a/_grains/users.py
+++ b/_grains/users.py
@@ -1,0 +1,34 @@
+"""Grain to get user accounts on a macOS system."""
+
+
+import logging
+import re
+
+import salt.modules.cmdmod
+import salt.utils.platform
+
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'users'
+
+
+def __virtual__():
+    if salt.utils.platform.is_darwin():
+        return __virtualname__
+    else:
+        return False
+
+# Chicken and egg problem, SaltStack style
+# __salt__ is already populated with grains by this stage.
+cmdmod = {
+    'cmd.run': salt.modules.cmdmod._run_quiet,
+}
+
+
+def all_users():
+    return {'macos_all_users': _get_users()}
+
+
+def _get_users():
+    return cmdmod['cmd.run']('dscl . list /Users').splitlines()

--- a/_grains/users_detailed.py
+++ b/_grains/users_detailed.py
@@ -1,0 +1,56 @@
+"""Grain to get user accounts on a macOS system."""
+
+
+import logging
+import re
+
+import salt.modules.cmdmod
+import salt.utils.platform
+
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'users'
+
+
+def __virtual__():
+    if salt.utils.platform.is_darwin():
+        return __virtualname__
+    else:
+        return False
+
+# Chicken and egg problem, SaltStack style
+# __salt__ is already populated with grains by this stage.
+cmdmod = {
+    'cmd.run': salt.modules.cmdmod._run_quiet,
+}
+
+
+def detailed_users():
+    return {'macos_users_detailed': {u['name']: u for u in _get_users()}}
+
+
+def _get_users():
+    result = cmdmod['cmd.run']('dscacheutil -q user')
+	# Example output:
+	# name: _reportmemoryexception
+	# password: *
+	# uid: 269
+	# gid: 269
+	# dir: /var/db/reportmemoryexception
+	# shell: /usr/bin/false
+	# gecos: ReportMemoryException
+    pattern = (
+        r'(?m)'
+        r'^name: (?P<name>.*?)\n'
+        r'^.*?\n'
+        r'^uid: (?P<uid>\d+)\n'
+        r'^gid: (?P<gid>\d+)\n'
+        r'^dir: (?P<dir>.*?)\n'
+        r'^shell: (?P<shell>.*?)\n'
+        r'^gecos: (?P<gecos>.*?)\n$')
+    return (m.groupdict() for m in re.finditer(pattern, result))
+
+
+if __name__ == "__main__":
+    print(users())


### PR DESCRIPTION
Not sure how you want to do this. I wrote one grain initially just because I wanted to be able to check that an account existed before using it for ownership in a state. Then I realized that I didn't necessarily want to double the length of my grains output just to get a user list, since doing *ALL* the accounts is really overkill in this situation. I also don't need to UID, home dir, etc.

So I wrote one that lists ALL the dscl output for each account on the device. One that does just a list of names of all accounts. And one that only shows the non-service accounts (i.e. don't start with a _).

I can merge these all into a single grain, but I figured this way someone could choose to add just the module they care about to their repo.

If there's a better way-I'm all ears 🌽 